### PR TITLE
Do not overwrite already valid `created_at` and do not make it invalid

### DIFF
--- a/customerio-client.js
+++ b/customerio-client.js
@@ -75,8 +75,8 @@ Client.prototype.identify = function createUser(customerid, email, data) {
   }
 
   data = _.clone(data);
-  data.created_at = Date.now();
-  data.email = email;
+  data.created_at = data.created_at || (Date.now() / 1000);
+  data.email = data.email || email;
 
   var deferred = Q.defer()
     , meta = this._requestData(customerid, 'PUT')


### PR DESCRIPTION
- when I pass valid `created_at` inside `data`, it gets overwritten because f\* me.
- Date.now() is number of milliseconds since Epoch, while customer.io expects number of seconds
